### PR TITLE
Add seed

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,3 @@
-
 name: 'dbt_training'
 version: '1.0.0'
 config-version: 2
@@ -12,9 +11,19 @@ seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-clean-targets:         
+target-path: "target" 
+clean-targets: 
   - "target"
   - "dbt_packages"
+
+seeds:
+  dbt_training:
+    sale_dates:
+      +column_types:
+        SALE_DATE: date
+        NAME: varchar
+        DISCOUNT_PERCENT: numeric(18,2)
+
 models:
   dbt_training:
     staging:
@@ -22,4 +31,4 @@ models:
     intermediate:
       +materialized: ephemeral
     marts:
-      +materialized: table 
+      +materialized: table

--- a/models/marts/orders.sql
+++ b/models/marts/orders.sql
@@ -24,6 +24,12 @@ customers as (
 
 ),
 
+sale_dates as (
+
+    select * from {{ ref('sale_dates') }}
+
+),
+
 
 final as (
 
@@ -36,7 +42,9 @@ final as (
         products.category,
         products.price,
         products.currency,
-        orders.quantity,        
+        orders.quantity,
+        sale_dates.sale_date is not null as is_sale_order,
+        nvl(sale_dates.discount_percent, 0) as discount_percent, 
         transactions.cost_per_unit_in_usd,
         transactions.amount_in_usd,
         transactions.tax_in_usd,
@@ -53,6 +61,9 @@ final as (
 
     left join customers
         on orders.customer_id = customers.customer_id
+
+    left join sale_dates
+        on date(orders.created_at) = date(sale_dates.sale_date)
 
 )
 

--- a/models/staging/tech_store/stg_tech_store__orders.sql
+++ b/models/staging/tech_store/stg_tech_store__orders.sql
@@ -14,7 +14,8 @@ final as (
         quantity,
         userid as employee_id,
         customerid as customer_id,
-        datetime as created_at
+        datetime as created_at,
+        date(datetime) as created_at_dt
 
     from orders
 

--- a/seeds/sale_dates.csv
+++ b/seeds/sale_dates.csv
@@ -1,0 +1,4 @@
+sale_date,name,discount_percent
+6/17/2019,Summer Sale,0.15
+9/17/2020,Fall Sale,0.20
+12/9/2021,Winter Flash Sale,0.4


### PR DESCRIPTION
### Summary
Add `sales_dates.csv` as a `seed` to better track orders during sales.

### Details
Added `sales_dates.csv` to `/seeds` directory
* Use as a `ref` in `orders` `mart` 

Updated `dbt_project.yml`
* Added new config section for `seeds`

Added `created_at_dt` to `stg_tech_store__orders`
   
### Checks
- [x] Follows style guide
- [x] Tested changes

### References
[dbt Seeds](https://docs.getdbt.com/docs/build/seeds)
