### PR TITLE
Add macro and var

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,6 +24,9 @@ seeds:
         NAME: varchar
         DISCOUNT_PERCENT: numeric(18,2)
 
+vars:
+  default_date: '9999-01-01'
+
 models:
   dbt_training:
     staging:

--- a/macros/utc_to_est.sql
+++ b/macros/utc_to_est.sql
@@ -1,0 +1,3 @@
+{% macro utc_to_est(column_name) -%}
+convert_timezone('UTC', 'America/New_York', {{ column_name }})
+{%- endmacro %}

--- a/models/marts/orders.sql
+++ b/models/marts/orders.sql
@@ -49,7 +49,9 @@ final as (
         transactions.amount_in_usd,
         transactions.tax_in_usd,
         transactions.total_charged_in_usd,
-        orders.created_at
+        orders.created_at,
+        orders.created_at_dt,
+        orders.created_at_est
 
     from orders
 
@@ -63,7 +65,7 @@ final as (
         on orders.customer_id = customers.customer_id
 
     left join sale_dates
-        on date(orders.created_at) = date(sale_dates.sale_date)
+        on orders.created_at_dt = sale_dates.sale_date
 
 )
 

--- a/models/staging/tech_store/stg_tech_store__customers.sql
+++ b/models/staging/tech_store/stg_tech_store__customers.sql
@@ -14,7 +14,9 @@ final as (
         cityid as city_id,
         mainsalesrepid as main_employee_id,
         createdatetime as created_at,
+        {{ utc_to_est('createdatetime') }} as created_at_est,
         updatedatetime as updated_at,
+        {{ utc_to_est('updatedatetime') }} as updated_at_est,
         iff(active = 'yes', true, false) as is_active
     
     from customers

--- a/models/staging/tech_store/stg_tech_store__employees.sql
+++ b/models/staging/tech_store/stg_tech_store__employees.sql
@@ -14,8 +14,9 @@ final as (
         lname as last_name,
         concat(first_name, ' ', last_name) as full_name,
         hiredate as hired_at,
-        enddate as terminated_at,
-        iff(terminated_at is null, true, false) as is_active 
+        nvl(enddate, '{{ var("default_date") }}') as terminated_at,
+        iff(terminated_at is null, true, false) as is_active
+
     from employees
 
 )

--- a/models/staging/tech_store/stg_tech_store__orders.sql
+++ b/models/staging/tech_store/stg_tech_store__orders.sql
@@ -15,6 +15,7 @@ final as (
         userid as employee_id,
         customerid as customer_id,
         datetime as created_at,
+        {{ utc_to_est('datetime') }} as created_at_est,
         date(datetime) as created_at_dt
 
     from orders


### PR DESCRIPTION
### Summary
Add custom `macro` & default `variable`

### Details
Added a new `macro`
* `utc_to_est` - Converts a UTC timestamp value to an Eastern Timezone value

Added a new `variable`
* `default_date` - Provides a default date for missing/null values ('9999-01-01')

### Checks
- [x] Follows style guide
- [x] Tested changes

### References
[Macros](https://docs.getdbt.com/docs/building-a-dbt-project/jinja-macros)
[Variables](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-variables)