### PR TITLE
Deploy to Production

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,6 +18,7 @@ clean-targets:
 
 seeds:
   dbt_training:
+    +schema: staging
     sale_dates:
       +column_types:
         SALE_DATE: date
@@ -31,9 +32,11 @@ models:
   dbt_training:
     staging:
       +materialized: view
+      +schema: staging
     intermediate:
       +materialized: ephemeral
     marts:
       +materialized: table
+      +schema: marts
       +tags:
         - p1

--- a/macros/get_custome_schema.sql
+++ b/macros/get_custome_schema.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {{ generate_schema_name_for_env(custom_schema_name, node) }}
+{%- endmacro %}

--- a/models/marts/_marts__models.yml
+++ b/models/marts/_marts__models.yml
@@ -8,10 +8,10 @@ models:
         description: The unique identifier for a single customer.
       - name: created_at_est
         tests: 
-          - not_negative
+          - unique
       - name: updated_at_est
         tests: 
-          - not_negative
+          - unique
 
   - name: orders
     description: '{{ doc("orders_table_description") }}'
@@ -20,4 +20,4 @@ models:
         description: The unique identifier for a single order.
       - name: created_at_est
         tests: 
-          - not_negative
+          - unique


### PR DESCRIPTION
### Summary
Deploy current project to Production

### Details
Add `prod` target to `sample-profiles.yml`
`get_custom_schema.sql` - Uses the built-in macros `generate_schema_name` and `generate_schema_name_for_env`
   * Will result in all models being deployed to a `target` schema in non-prod environments (ex. `dev`, `qa`)
   * If `target` =  `prod` all models will be deployed to the individual custom schemas (ex. `staging`, `mart`)

Confirmed ability to deploy to `prod`.

### Checks
- [x] Follows style guide
- [x] Tested changes

### References
[Target](https://docs.getdbt.com/reference/dbt-jinja-functions/target)
[Using Custom Schemas](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-custom-schemas)

